### PR TITLE
fix: add MCP server path for Ark v0.1.49 compatibility

### DIFF
--- a/mcp/ai-developer-guide-mcp/chart/templates/mcpserver.yaml
+++ b/mcp/ai-developer-guide-mcp/chart/templates/mcpserver.yaml
@@ -11,6 +11,7 @@ spec:
       serviceRef:
         name: {{ include "ai-developer-guide-mcp.fullname" . }}
         port: http
+        path: /mcp
   transport: http
   {{- if .Values.mcpServer.description }}
   description: {{ .Values.mcpServer.description | quote }}


### PR DESCRIPTION
## Summary

- Add `path: /mcp` to MCPServer template
- Required for compatibility with Ark v0.1.49+ which no longer auto-appends paths

Related: mckinsey/agents-at-scale-ark#502