### PR TITLE
feat: add Google Analytics (GA4 G-WFTE4NBDQ1)

### DIFF
--- a/.github/scripts/generate_json.py
+++ b/.github/scripts/generate_json.py
@@ -255,6 +255,14 @@ def create_index_html(output_dir, generated_guides, project_dir):
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AI Developer Guide API</title>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WFTE4NBDQ1"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){{dataLayer.push(arguments);}}
+      gtag('js', new Date());
+      gtag('config', 'G-WFTE4NBDQ1');
+    </script>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
 </head>


### PR DESCRIPTION
## Summary
- Add Google Analytics 4 (GA4 `G-WFTE4NBDQ1`) tracking to the generated site.
- Inject the gtag.js snippet into the `<head>` of the generated `index.html` in `.github/scripts/generate_json.py` (the site's only user-facing HTML page).